### PR TITLE
Lots of general fixes, nothing major.

### DIFF
--- a/Bravais.cpp
+++ b/Bravais.cpp
@@ -10,6 +10,7 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 	
 	std::string cellType = crystal.getCellType();
 	std::string cellCentering = crystal.getCellCentering();
+	std::string cellName = crystal.getCellName();
 	
 	double a = crystal.getAxialDistanceA();
 	double b = crystal.getAxialDistanceB();
@@ -20,7 +21,8 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 	double alpha = crystal.getAxialAngleAlpha()* (pi/180.);
 	double beta = crystal.getAxialAngleBeta() * (pi / 180.);
 	double gamma = crystal.getAxialAngleGamma() * (pi / 180.);
-	Eigen::MatrixXd cellStructure;
+
+	//Eigen::MatrixXd cellStructure;
 
 	//Fix the general Case!!
 	/*if (cellType == "triclinic") { // 3 different atomic spacing, 3 different axial angles
@@ -33,91 +35,96 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 
 	if (cellType == "monoclinic") {
 		if (cellCentering != "primative" or cellCentering != "base-centered") {
-			std::cout << "WARNING: centering not recognized for this cellType, using primative case instead \n";
 			cellCentering = "primative";
 		}
 		if (cellCentering == "primative") {
 			Eigen::MatrixXd cellStructure(8, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, b* std::sin(beta), c* std::cos(beta);
-			cellStructure << a, b* std::sin(beta), c* std::cos(beta);
-			cellStructure << 0, 0, c* std::sin(beta);
-			cellStructure << a, 0, c* std::sin(beta) + b * std::cos(beta);
-			cellStructure << 0, b* std::sin(beta), (c * std::sin(beta)) + b * std::cos(beta);
-			cellStructure << a, b* std::sin(beta), (c * std::sin(beta)) + b * std::cos(beta);
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, b* std::sin(beta), c* std::cos(beta);
+			cellStructure.row(3) << a, b* std::sin(beta), c* std::cos(beta);
+			cellStructure.row(4) << 0, 0, c* std::sin(beta);
+			cellStructure.row(5) << a, 0, c* std::sin(beta) + b * std::cos(beta);
+			cellStructure.row(6) << 0, b* std::sin(beta), (c * std::sin(beta)) + b * std::cos(beta);
+			cellStructure.row(7) << a, b* std::sin(beta), (c * std::sin(beta)) + b * std::cos(beta);
+			return cellStructure;
 		}
 		else if (cellCentering == "base-centered") {
 			Eigen::MatrixXd cellStructure(14, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, b* std::sin(beta), c* std::cos(beta);
-			cellStructure << a, b* std::sin(beta), c* std::cos(beta);
-			cellStructure << 0, 0, c* std::sin(beta);
-			cellStructure << a, 0, c* std::sin(beta) + b * std::cos(beta);
-			cellStructure << 0, b* std::sin(beta), c* std::sin(beta) + b * std::cos(beta);
-			cellStructure << a, b* std::sin(beta), c* std::sin(beta) + b * std::cos(beta);
-			cellStructure << a / 2, b* std::sin(beta) / 2, (c * std::cos(beta) / 2);
-			cellStructure << a / 2, b* std::sin(beta) / 2, (c * std::cos(beta) / 2) + (b * std::cos(beta) / 2);
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, b* std::sin(beta), c* std::cos(beta);
+			cellStructure.row(3) << a, b* std::sin(beta), c* std::cos(beta);
+			cellStructure.row(4) << 0, 0, c* std::sin(beta);
+			cellStructure.row(5) << a, 0, c* std::sin(beta) + b * std::cos(beta);
+			cellStructure.row(6) << 0, b* std::sin(beta), c* std::sin(beta) + b * std::cos(beta);
+			cellStructure.row(7) << a, b* std::sin(beta), c* std::sin(beta) + b * std::cos(beta);
+			cellStructure.row(8) << a / 2, b* std::sin(beta) / 2, (c * std::cos(beta) / 2);
+			cellStructure.row(9) << a / 2, b* std::sin(beta) / 2, (c * std::cos(beta) / 2) + (b * std::cos(beta) / 2);
+			return cellStructure;
 		}
 	}
 	else if (cellType == "orthorhombic") { //
 		if (cellCentering == "primative") {
 			Eigen::MatrixXd cellStructure(8, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, b, 0;
-			cellStructure << 0, 0, c;
-			cellStructure << a, b, 0;
-			cellStructure << a, 0, c;
-			cellStructure << 0, b, c;
-			cellStructure << a, b, c;
-			}
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, b, 0;
+			cellStructure.row(3) << 0, 0, c;
+			cellStructure.row(4) << a, b, 0;
+			cellStructure.row(5) << a, 0, c;
+			cellStructure.row(6) << 0, b, c;
+			cellStructure.row(7) << a, b, c;
+			return cellStructure;
+		}
 		if (cellCentering == "base-centered") {
 			Eigen::MatrixXd cellStructure(10, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, b, 0;
-			cellStructure << 0, 0, c;
-			cellStructure << a, b, 0;
-			cellStructure << a, 0, c;
-			cellStructure << 0, b, c;
-			cellStructure << a, b, c;
-			cellStructure << a / 2., b / 2., 0;
-			cellStructure << a / 2., b / 2., c;
-			}
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, b, 0;
+			cellStructure.row(3) << 0, 0, c;
+			cellStructure.row(4) << a, b, 0;
+			cellStructure.row(5) << a, 0, c;
+			cellStructure.row(6) << 0, b, c;
+			cellStructure.row(7) << a, b, c;
+			cellStructure.row(8) << a / 2., b / 2., 0;
+			cellStructure.row(9) << a / 2., b / 2., c;
+			return cellStructure;
+		}
 		if (cellCentering == "body-centered") {
 			Eigen::MatrixXd cellStructure(9, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, b, 0;
-			cellStructure << 0, 0, c;
-			cellStructure << a, b, 0;
-			cellStructure << a, 0, c;
-			cellStructure << 0, b, c;
-			cellStructure << a, b, c;
-			cellStructure << a / 2., b / 2., c / 2.;
-			}
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, b, 0;
+			cellStructure.row(3) << 0, 0, c;
+			cellStructure.row(4) << a, b, 0;
+			cellStructure.row(5) << a, 0, c;
+			cellStructure.row(6) << 0, b, c;
+			cellStructure.row(7) << a, b, c;
+			cellStructure.row(8) << a / 2., b / 2., c / 2.;
+			return cellStructure;
+		}
 		if (cellCentering == "face-centered") {
 			Eigen::MatrixXd cellStructure(14, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, b, 0;
-			cellStructure << 0, 0, c;
-			cellStructure << a, b, 0;
-			cellStructure << a, 0, c;
-			cellStructure << 0, b, c;
-			cellStructure << a, b, c;
-			cellStructure << a / 2., b / 2., 0;
-			cellStructure << a / 2., b / 2., c / 2;
-			cellStructure << 0., b / 2., c / 2;
-			cellStructure << a, b / 2., c / 2;
-			cellStructure << a / 2., 0., c / 2.;
-			cellStructure << a / 2., b, c / 2;
-			}
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, b, 0;
+			cellStructure.row(3) << 0, 0, c;
+			cellStructure.row(4) << a, b, 0;
+			cellStructure.row(5) << a, 0, c;
+			cellStructure.row(6) << 0, b, c;
+			cellStructure.row(7) << a, b, c;
+			cellStructure.row(8) << a / 2., b / 2., 0;
+			cellStructure.row(9) << a / 2., b / 2., c / 2;
+			cellStructure.row(10) << 0., b / 2., c / 2;
+			cellStructure.row(11) << a, b / 2., c / 2;
+			cellStructure.row(12) << a / 2., 0., c / 2.;
+			cellStructure.row(13) << a / 2., b, c / 2;
+			return cellStructure;
+		}
 		else {
-				std::cout << "WARNING: centering not recognized for this cellType \n";
-			}
+			std::cout << "WARNING: centering not recognized for this cellType \n";
+		}
 	}
 	else if (cellType == "tetragonal") {
 		if (cellCentering != "primative" or cellCentering != "body-centered") {
@@ -126,27 +133,29 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 			}
 		if (cellCentering == "primative") {
 			Eigen::MatrixXd cellStructure(8, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, a, 0;
-			cellStructure << 0, 0, c;
-			cellStructure << a, a, 0;
-			cellStructure << a, 0, c;
-			cellStructure << 0, a, c;
-			cellStructure << a, a, c;
-			}
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, a, 0;
+			cellStructure.row(3) << 0, 0, c;
+			cellStructure.row(4) << a, a, 0;
+			cellStructure.row(5) << a, 0, c;
+			cellStructure.row(6) << 0, a, c;
+			cellStructure.row(7) << a, a, c;
+			return cellStructure;
+		}
 		if (cellCentering == "body-centered") {
 			Eigen::MatrixXd cellStructure(9, 3);
-			cellStructure << 0, 0, 0;
-			cellStructure << a, 0, 0;
-			cellStructure << 0, a, 0;
-			cellStructure << 0, 0, c;
-			cellStructure << a, a, 0;
-			cellStructure << a, 0, c;
-			cellStructure << 0, a, c;
-			cellStructure << a, a, c;
-			cellStructure << a / 2., a / 2., c / 2.;
-			}
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << 0, a, 0;
+			cellStructure.row(3) << 0, 0, c;
+			cellStructure.row(4) << a, a, 0;
+			cellStructure.row(5) << a, 0, c;
+			cellStructure.row(6) << 0, a, c;
+			cellStructure.row(7) << a, a, c;
+			cellStructure.row(8) << a / 2., a / 2., c / 2.;
+			return cellStructure;
+		}
 
 		else {
 				std::cout << "WARNING: centering not recognized for this cellType \n";
@@ -158,15 +167,15 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 				cellCentering = "primative";
 		}
 		Eigen::MatrixXd cellStructure(8, 3);
-		cellStructure << 0, 0, 0;
-		cellStructure << a * std::sin(alpha), a* std::cos(alpha), a* std::cos(alpha);
-		cellStructure << a * std::cos(alpha), a* std::sin(alpha), a* std::cos(alpha);
-		cellStructure << a * std::sin(alpha), a* std::sin(alpha), a* std::cos(alpha);
-		cellStructure << a * std::cos(alpha), a* std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
-		cellStructure << a * std::sin(alpha) + a * std::cos(alpha), a* std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
-		cellStructure << a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
-		cellStructure << a * std::sin(alpha) + a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
-
+		cellStructure.row(0) << 0, 0, 0;
+		cellStructure.row(1) << a * std::sin(alpha), a* std::cos(alpha), a* std::cos(alpha);
+		cellStructure.row(2) << a * std::cos(alpha), a* std::sin(alpha), a* std::cos(alpha);
+		cellStructure.row(3) << a * std::sin(alpha), a* std::sin(alpha), a* std::cos(alpha);
+		cellStructure.row(4) << a * std::cos(alpha), a* std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
+		cellStructure.row(5) << a * std::sin(alpha) + a * std::cos(alpha), a* std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
+		cellStructure.row(6) << a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
+		cellStructure.row(7) << a * std::sin(alpha) + a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha), a* std::sin(alpha) + a * std::cos(alpha);
+		return cellStructure;
 
 	}
 	else if (cellType == "hexagonal") {
@@ -175,18 +184,18 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 				cellCentering = "primative";
 		}
 		Eigen::MatrixXd cellStructure(8, 3);
-		cellStructure << 0, 0, 0;
-		cellStructure << a, 0, 0;
-		cellStructure << -a * std::sin(pi / 6.), a* std::cos(pi / 6.), 0;
-		cellStructure << a - a * std::sin(pi / 6.), a* std::cos(pi / 6.), 0;
-		cellStructure << 0, 0, c;
-		cellStructure << a, 0, c;
-		cellStructure << -a * std::sin(pi / 6.), a* std::cos(pi / 6.), c;
-		cellStructure << a - a * std::sin(pi / 6.), a* std::cos(pi / 6.), c;
+		cellStructure.row(0) << 0, 0, 0;
+		cellStructure.row(1) << a, 0, 0;
+		cellStructure.row(2) << -a * std::sin(pi / 6.), a* std::cos(pi / 6.), 0;
+		cellStructure.row(3) << a - a * std::sin(pi / 6.), a* std::cos(pi / 6.), 0;
+		cellStructure.row(4) << 0, 0, c;
+		cellStructure.row(5) << a, 0, c;
+		cellStructure.row(6) << -a * std::sin(pi / 6.), a* std::cos(pi / 6.), c;
+		cellStructure.row(7) << a - a * std::sin(pi / 6.), a* std::cos(pi / 6.), c;
+		return cellStructure;
 
 	}
 	else if (cellType == "cubic") {
-
 		if (cellCentering == "primative") {
 			Eigen::MatrixXd cellStructure(8, 3);
 			cellStructure.row(0) << 0, 0, 0;
@@ -197,7 +206,6 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 			cellStructure.row(5) << a, 0, a;
 			cellStructure.row(6) << 0, a, a;
 			cellStructure.row(7) << a, a, a;
-
 			return cellStructure;
 		}
 
@@ -238,11 +246,59 @@ Eigen::MatrixXd getCellStructure(const Crystal& crystal){
 				std::cout << "WARNING: centering not recognized for this cellType \n";
 		}
 	}
-	else {
-		std::cout << "WARNING: cellType not recognized, returing empty cell structure \n";
+
+	else if (cellType == "unique") {
+		if (cellName == "twoCrystal") {
+			if (cellCentering == "primative") {
+				Eigen::MatrixXd cellStructure(1, 3);
+				cellStructure.row(0) << 0, 0, 0;
+				return cellStructure;
+			}
+			else {
+				std::cout << "The two crystal testing objet can only be set to centering = primative, any other centering is nonsense. Fix and rerun. ";
+				throw;
+			}
+		}
+		else if (cellName == "loss") {
+			Eigen::MatrixXd cellStructure(20, 3);
+			//  |
+			cellStructure.row(0) << 0, -2. * a, 3. * a;
+			cellStructure.row(1) << 0, -2. * a, 2. * a;
+			cellStructure.row(2) << 0, -2. * a, 1. * a;
+			//  ||
+			cellStructure.row(3) << 0, a, 3. * a;
+			cellStructure.row(4) << 0, a, 2. * a;
+			cellStructure.row(5) << 0, a, 1. * a;
+			cellStructure.row(6) << 0, 2. * a, 2. * a;
+			cellStructure.row(7) << 0, 2. * a, a;
+			//  ||
+			cellStructure.row(8) << 0, -2. * a, -3. * a;
+			cellStructure.row(9) << 0, -2. * a, -2. * a;
+			cellStructure.row(10) << 0, -2. * a, -1. * a;
+			cellStructure.row(11) << 0, -1. * a, -3. * a;
+			cellStructure.row(12) << 0, -1. * a, -2. * a;
+			cellStructure.row(13) << 0, -1. * a, -1. * a;
+			// |_
+			cellStructure.row(14) << 0, a, -1. * a;
+			cellStructure.row(15) << 0, a, -2. * a;
+			cellStructure.row(16) << 0, a, -3. * a;
+			cellStructure.row(17) << 0, 1.5 * a, -2.5 * a;
+			cellStructure.row(18) << 0, 2.5 * a, -2.5 * a;
+			cellStructure.row(19) << 0, 3.5 * a, -2.5 * a;
+			return cellStructure;
+		}
+		else if (cellName == "graphite2D") {
+			Eigen::MatrixXd cellStructure(4, 3);
+			cellStructure.row(0) << 0, 0, 0;
+			cellStructure.row(1) << a, 0, 0;
+			cellStructure.row(2) << -a * std::sin(pi / 6.), a* std::cos(pi / 6.), 0;
+			cellStructure.row(3) << a - a * std::sin(pi / 6.), a* std::cos(pi / 6.), 0;
+			return cellStructure;
+
+		}
+		else {
+			std::cout << "WARNING: cellType not recognized, returing empty cell structure \n";
+		}
 	}
-	
-	//return cellStructure;	
+
 }
-
-

--- a/Crystal.cpp
+++ b/Crystal.cpp
@@ -20,7 +20,6 @@ void Crystal::setCellStrings(const Config& config) {
 
 
 void Crystal::setCellType(Crystal& crystal) {
-//void Crystal::setCellType(std::string cellName, std::string cellCentering) {
 	
 	const std::string cellCentering = crystal.getCellCentering();
 	const std::string cellName = crystal.getCellName();
@@ -31,6 +30,8 @@ void Crystal::setCellType(Crystal& crystal) {
 	std::string rhombohedralArray[1] = {"dolomite"};
 	std::string hexagonalArray[1] = { "graphite" };
 	std::string cubicArray[1] = { "salt" };
+	std::string uniqueArray[2] = { "twoCrystal", "loss"}; // Used for testing purposes, just return two open holes as a crystal
+
 
 	if (std::find(std::begin(monoclinicArray), std::end(monoclinicArray), cellName) != std::end(monoclinicArray) && (cellCentering == "primative" || "base-centered")) {
 		
@@ -56,6 +57,10 @@ void Crystal::setCellType(Crystal& crystal) {
 	{
 		this->cellType = "cubic";
 	}
+	else if (std::find(std::begin(uniqueArray), std::end(uniqueArray), cellName) != std::end(uniqueArray) && (cellCentering == "primative" || "body-centered" || "face-centered"))
+	{
+		this->cellType = "unique";
+	}
 	else
 	{
 		std::cout << "Cell name not recognized, Name: " << cellName << " and Centering: " << cellCentering << " is not a valid configuration, check again.";
@@ -71,7 +76,6 @@ void Crystal::setCellProperties(Crystal& crystal) {
 	const std::string cellCentering = crystal.getCellCentering();
 
 	if (cellName == "graphite") { // https://som.web.cmu.edu/structures/S022-C-graphite.html
-
 		Crystal::setAxialDistanceA(2.456e-10);
 		Crystal::setAxialDistanceB(2.456e-10);
 		Crystal::setAxialDistanceC(6.696e-10);
@@ -125,6 +129,36 @@ void Crystal::setCellProperties(Crystal& crystal) {
 		Crystal::setAxialDistanceA(4.815e-10);
 		Crystal::setAxialDistanceB(4.815e-10);
 		Crystal::setAxialDistanceC(16.119e-10);
+
+		Crystal::setAxialAngleAlpha(90);
+		Crystal::setAxialAngleBeta(90);
+		Crystal::setAxialAngleGamma(120);
+	}
+	else if (cellName == "twoCrystal") { // https://www.mindat.org/min-1304.html
+
+		Crystal::setAxialDistanceA(5.59e-10);
+		Crystal::setAxialDistanceB(5.59e-10);
+		Crystal::setAxialDistanceC(5.59e-10);
+
+		Crystal::setAxialAngleAlpha(90);
+		Crystal::setAxialAngleBeta(90);
+		Crystal::setAxialAngleGamma(90);
+	}
+
+	else if (cellName == "loss") { // :(
+		Crystal::setAxialDistanceA(5.59e-10);
+		Crystal::setAxialDistanceB(5.59e-10);
+		Crystal::setAxialDistanceC(5.59e-10);
+
+		Crystal::setAxialAngleAlpha(90);
+		Crystal::setAxialAngleBeta(90);
+		Crystal::setAxialAngleGamma(90);
+	}
+
+	else if (cellName == "graphite2D") { // :(
+		Crystal::setAxialDistanceA(2.456e-10);
+		Crystal::setAxialDistanceB(2.456e-10);
+		Crystal::setAxialDistanceC(0);
 
 		Crystal::setAxialAngleAlpha(90);
 		Crystal::setAxialAngleBeta(90);

--- a/Crystal.h
+++ b/Crystal.h
@@ -10,8 +10,6 @@
 
 class Crystal {
 public:
-	//Crystal();
-	//virtual ~Crystal();
 
 	const double getAxialDistanceA() const { return axialDistanceA; }
 	const double getAxialDistanceB() const { return axialDistanceB; }

--- a/EigenLaueDiffraction.vcxproj
+++ b/EigenLaueDiffraction.vcxproj
@@ -102,7 +102,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
@@ -116,7 +116,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>

--- a/config.cpp
+++ b/config.cpp
@@ -3,47 +3,66 @@
 #include <Crystal.h>
 #include <config.h>
 #include <fstream>
-#include <iostream>
+#include <iostream> 
 #include <math.h>
 #include <Eigen\Dense>
 
 //setManualConfig is the easiest way to produce one image for testing purposes
-void Config::setManualConfig() {
+void Config::setManualConfigTag(Config &config) {
+	std::stringstream configTag;
+	double xpos_str = config.getWallXPosition();
+	double dzdy_str = config.getdzdy();
+	double len_str = config.getWallLength();
+	double lambda_str = config.getLambda();
+	double theta_str = config.getTheta();
+	double psi_str = config.getPsi();
+	double phi_str = config.getPhi();
+	double nx_str = config.getnx();
+	double ny_str = config.getny();
+	double nz_str = config.getnz();
+
+	std::string name_str = config.getCellName();
+	std::string centering_str = config.getCellCentering();
+	 
+	// Combine them all in a similar way s.t. we can use the plotting script for the rotating case
 	
-	Config::setWallXPosition(0.5);
-	Config::setdzdy(0.005);
-	Config::setWallLength(.05);
-	Config::setLambda(1.e-9);
-	Config::setA(1.);
-	Config::setk(1.);
-	Config::setOmega(0.);
+	std::fixed;
+	configTag << "CONFIG_" << xpos_str << "XPOS_" << dzdy_str << "DZDY_" << len_str << "LEN_" << theta_str << "THETA_" << phi_str << "PHI_" << psi_str << "PSI_" << nx_str << "NX_" << ny_str << "NY_" << nz_str << "NZ_" << lambda_str << "LAMBDA_";
+	std::string fullConfigTag = configTag.str() + centering_str + "CENTERING_" + name_str + "NAME_CONFIG_";
+	config.setConfigTag(fullConfigTag);
+}
+
+void Config::setManualConfig() {
+
+	Config::setWallXPosition(1.e-2);
+	Config::setdzdy(1.e-3);
+	Config::setWallLength(1.e-1);
+	Config::setLambda(1.e-10);
+	Config::setk(8 * std::atan(1.) / Config::getLambda()); //  (2*pi) /  lambda
 	Config::setTheta(0.);
 	Config::setPhi(0.);
 	Config::setPsi(0.);
-	Config::setl(2.);
-	Config::seta(1.5);
-	Config::setnx(1);
+	Config::setl(3.); // Number of l-terms in ylm to include (drops off rather hard after ~2)
+	Config::seta(1.e-10); //1.e-10 // "Atomic size" used for scattering calculation, set to about 1 angstrom  ** ENFORCE A LIMIT that this must be small, or generalize with another flag if we want to use this for macroscpoic objects
+	Config::setnx(1);  // number of copies of cells in x,y,z 
 	Config::setny(1);
 	Config::setnz(1);
-
 	Config::setWallDivisions(Config::getdzdy(), Config::getWallLength());
 
 	//Config::setSaveString("C:\\Users\\Michael\\Documents\\Programming\\laueDiffractionResults\\rotationTests\\EigenResultsFaceHighRes.csv");
 	Config::setCellCentering("primative");
 	Config::setCellName("salt");
 	Config::setCellType("");
-	Config::setConfigTag("_NoTag_");
+	Config::setConfigTag("_ShouldNotAppear_");
 }
 
 //setFullConfig is meant to be used to automate large numbers of pictures at different distances, spacings, wavelengths etc... 
-void Config::setFullConfig(double wallXPosition, double dzdy, double wallLength, double lambda, double A, double k, double omega, double theta, double phi, double psi , int l, double a,  std::string cellCentering , std::string cellName , std::string configTag, int nx, int ny, int nz) { //std::string cellType, std::string configTag) {
+void Config::setFullConfig(double wallXPosition, double dzdy, double wallLength, double lambda, double theta, double phi, double psi, int l, double a, int nx, int ny, int nz, std::string cellCentering, std::string cellName, std::string configTag) { //std::string cellType, std::string configTag) {
 	Config::setWallXPosition(wallXPosition);
 	Config::setdzdy(dzdy);
 	Config::setWallLength(wallLength);
 	Config::setLambda(lambda);
-	Config::setA(A);
-	Config::setk(k);
-	Config::setOmega(omega);
+	Config::setk(8 * std::atan(1.) / Config::getLambda());
 	Config::setTheta(theta);
 	Config::setPhi(phi);
 	Config::setPsi(psi);
@@ -56,13 +75,8 @@ void Config::setFullConfig(double wallXPosition, double dzdy, double wallLength,
 
 	Config::setCellCentering(cellCentering);
 	Config::setCellName(cellName);
-	//Config::setCellType(cellType);
 	Config::setConfigTag(configTag);
-
 }
 
-void Config::setSaveString(Config config) {
-
-}
 
 

--- a/config.h
+++ b/config.h
@@ -22,14 +22,12 @@ public:
 	const double getdzdy() const { return dzdy; }
 	const double getWallLength() const { return wallLength; }
 	const double getLambda() const { return lambda; }
-	const double getA() const { return A; }
 	const double getk() const { return k; }
-	const double getOmega() const { return omega; }
 	const double getTheta() const { return theta; }
 	const double getPhi() const { return phi; }
 	const double getPsi() const { return psi; }
 	const int getl() const { return l; }
-	const double geta() const { return a; } // a in this case refers to the atomic size
+	const double geta() const { return a; } 
 	const int getWallDivisions() const { return wallDivisions; }
 
 	std::string getSaveString() { return saveString; }
@@ -39,9 +37,7 @@ public:
 	void setdzdy(double _dzdy) { this->dzdy = _dzdy; }
 	void setWallLength(double _wallLength) { this->wallLength = _wallLength; }
 	void setLambda(double _lambda) { this->lambda = _lambda; }
-	void setA(double _A) { this->A = _A; }
 	void setk(double _k) { this->k = _k; }
-	void setOmega(double _omega) { this->omega = _omega; }
 	void setTheta(double _theta) { this->theta = _theta; }
 	void setPhi(double _phi) { this->phi = _phi; }
 	void setPsi(double _psi) { this->psi = _psi; }
@@ -58,7 +54,8 @@ public:
 	
 	void setSaveString(Config config);
 	void setManualConfig();
-	void setFullConfig(double _wallXPosition, double _dzdy, double _wallLength, double _lambda, double _A, double _k, double _omega, double _theta, double _phi, double _psi, int _l, double _a, std::string _cellCentering, std::string _cellName, std::string _configTag, int _nx, int _ny, int _nz);
+	void setManualConfigTag(Config &config);
+	void setFullConfig(double _wallXPosition, double _dzdy, double _wallLength, double _lambda, double _theta, double _phi, double _psi, int _l, double _a, int _nx, int _ny, int _nz, std::string _cellCentering, std::string _cellName, std::string _configTag);
 	
 	const std::string getCellName() const { return cellName; }
 	const std::string getCellType() const { return cellType; }
@@ -70,19 +67,17 @@ private:
 	int ny = 1;
 	int nz = 1;
 
-	double wallXPosition = 0.01;// wall at x = wallXPos
-	double dzdy = 0.0002;// dzdy->step size for wall spacing
-	double wallLength = .1; // wall is wallLen x wallLen meters
+	double wallXPosition = 0.01;// wall at x = wallXPos meters
+	double dzdy = 0.0002;// dzdy->step size for wall spacing on a flat surface
+	double wallLength = .1; // wall is wallLen x wallLen meters in area
 	double lambda = 1e-9; // wavelength (meters)
-	double A = 1;  // Amplitude (arbitrary units)
-	double k = 6.2832 / 3.e-9; // wavenumber (1/m)
-	double omega = 0; //
-	double theta = 0;
-	double phi = 0;
-	double psi = 0;
-	int wallDivisions; //= static_cast<int>(std::floor(wallLength / dzdy));
-	int l = 3; // number of spherical harmonics to include
-	double a = 1.;
+	double k = 6.2832 / 3.e-9; // wavenumber (2 * pi / lambda)
+	double theta = 0; // Rotation around __ axis
+	double phi = 0; // Rotation around __ axis
+	double psi = 0; // Rotation around __ axis
+	int wallDivisions; // number of bins in the square (flat) wall
+	int l = 3; // number of spherical harmonics to include (eventually will investigate this, but higher than l=1 or l=2 may )
+	double a = 1.;// a refers to the atomic size
 
 	// Defaults 
 	std::string cellName = "salt";


### PR DESCRIPTION
Physical values can now be used in appropriate palces

Added a test crystal (twoCrystal) to act as a reliable tester to figure out orientations in the next session

Updated the submission script as well as the manual config option

No longer uses amplitude and lambda-derived variables such as omega, k.

congif.a needs to become crystal.a as this is a property that will change with each composition